### PR TITLE
added token passing to all tabs

### DIFF
--- a/ChemoTracker/MenuNavigation.js
+++ b/ChemoTracker/MenuNavigation.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Component} from 'react';
 import { Platform } from 'react-native';
 import { NavigationComponent } from 'react-native-material-bottom-navigation';
 import { TabNavigator, TabBarBottom } from 'react-navigation';
@@ -11,7 +11,7 @@ import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import OctiIcon from 'react-native-vector-icons/Octicons';
 import color from './styles/color.js';
 
-const Menu = TabNavigator({
+const MainContainer = TabNavigator({
   Home: {
     screen: HomeStackNav,
     path: '',
@@ -45,22 +45,31 @@ const Menu = TabNavigator({
     },
   }
 }, {
-    tabBarPosition: 'bottom',
-    tabBarOptions: {
-      showIcon: true,
-      showLabel: false,
-      activeTintColor: color.navBarIcon,
-      inactiveTintColor: color.navBarRipple,
-      indicatorStyle: {
-        backgroundColor: 'transparent'
-      },
-      style: {
-        backgroundColor: color.navBarBackground,
-      },
+  tabBarPosition: 'bottom',
+  tabBarOptions: {
+    showIcon: true,
+    showLabel: false,
+    activeTintColor: color.navBarIcon,
+    inactiveTintColor: color.navBarRipple,
+    indicatorStyle: {
+      backgroundColor: 'transparent'
     },
-    animationEnabled: false,
-    swipeEnabled: true,
+    style: {
+      backgroundColor: color.navBarBackground,
+    },
+  },
+  animationEnabled: false,
+  swipeEnabled: true,
+});
+
+class Menu extends Component {
+  constructor(props) {
+    super(props);
   }
-);
+  render() {
+    const token = this.props.navigation.state.params;
+    return <MainContainer screenProps={token}/>;
+  }
+}
 
 export default Menu;

--- a/ChemoTracker/MenuNavigation.js
+++ b/ChemoTracker/MenuNavigation.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import { Platform } from 'react-native';
 import { NavigationComponent } from 'react-native-material-bottom-navigation';
 import { TabNavigator, TabBarBottom } from 'react-navigation';

--- a/ChemoTracker/components/Calendar/Calendar.js
+++ b/ChemoTracker/components/Calendar/Calendar.js
@@ -10,16 +10,14 @@ import CalendarEvent from './event.js';
 import _ from 'lodash';
 import moment from 'moment';
 import { getSymptoms, getSymptomsByMonth, getFilePath } from '../../services/symptomTracking.js';
-import { login } from '../../services/login.js';
-
-let token = '';
 
 class Calendar extends Component {
   constructor(props){
     super(props);
     this.state = {
       listOfItems: {},
-      calendarItems: {}
+      calendarItems: {},
+      token: props.screenProps.token
     }
     this.onDayPress = this.onDayPress.bind(this);
     this.rowHasChanged = this.rowHasChanged.bind(this);
@@ -35,16 +33,9 @@ class Calendar extends Component {
   }
 
   loadItemsMonthly(ds){
-    login("seven@seven.com", "mustaqeem")
-    .then(t => {
-      token = t;
-      getSymptoms()
-      .then(symptomsList => {
-        this.getItemsByMonth(ds, symptomsList);
-      })
-      .catch(err => {
-        console.log(err);
-      })
+    getSymptoms()
+    .then(symptomsList => {
+      this.getItemsByMonth(ds, symptomsList);
     })
     .catch(err => {
       console.log(err);
@@ -54,7 +45,7 @@ class Calendar extends Component {
   getItemsByMonth(ds, symptomsList) {
     const year = moment(ds).format('YYYY');
     const month = moment(ds).format('M');
-    getSymptomsByMonth(year, month, token.key)
+    getSymptomsByMonth(year, month, this.state.token)
     .then(list => {
       // map the list with appropriate data for FE
       let mappedList = [];

--- a/ChemoTracker/components/Home.js
+++ b/ChemoTracker/components/Home.js
@@ -7,6 +7,7 @@ import styles from '../styles/main.js';
 import color from '../styles/color.js';
 
 class Home extends Component {
+
   static navigationOptions = {
     tabBarLabel: "Home",
     tabBarIcon: () => (<Icon size={24} name="home" color={color.navBarIcon} />)
@@ -15,6 +16,7 @@ class Home extends Component {
     super(props);
     this.state = {
       fontLoaded: false,
+      token: props.screenProps.token
     };
   }
 


### PR DESCRIPTION
- token is now available in all tabs. See `MenuNavigation.js` to see how to pass it in, in case you want to pass it into another child inside your feature.
- to get the token, use `props.screenProps.token`. Example can be seen in `Calendar.js` and for `Home.js`, I already put it inside `this.state.token`